### PR TITLE
Replace old /account/balance with the new one

### DIFF
--- a/epoch/api/account_api_usage.md
+++ b/epoch/api/account_api_usage.md
@@ -4,7 +4,6 @@
 Each node handles one account.
 
 The following assumes that the node exposes at address 127.0.0.1 the following ports:
-* HTTP external API: 3013
 * HTTP internal API: 3113
 
 ## Retrieve your public key
@@ -20,9 +19,9 @@ You shall read output like the following:
 
 ## Retrieve your balance
 
-In order to retrieve your balance, retrieve your public key then retrieve the balance associated to the retrieved public key (replace the public key in the command):
+In order to retrieve your balance, fetch your public key then use it to get the balance associated to that public key (replace the public key in the command):
 ```bash
-curl -G http://127.0.0.1:3013/v2/account/balance --data-urlencode 'pub_key=ak$3N1WLMewMQPUyQBdEhXRSYee84RQNKJrECwbbseMkNsZhv1XLjpmiqjAkvSRpQ6kgWJMjq9dTmdQ3ekuhpscJk6LpjJYk4'
+curl -G http://127.0.0.1:3113/v2/account/balance/ak$3N1WLMewMQPUyQBdEhXRSYee84RQNKJrECwbbseMkNsZhv1XLjpmiqjAkvSRpQ6kgWJMjq9dTmdQ3ekuhpscJk6LpjJYk4'
 ```
 You shall read output like the following...
 ```

--- a/epoch/api/account_api_usage.md
+++ b/epoch/api/account_api_usage.md
@@ -21,7 +21,7 @@ You shall read output like the following:
 
 In order to retrieve your balance, fetch your public key then use it to get the balance associated to that public key (replace the public key in the command):
 ```bash
-curl -G http://127.0.0.1:3113/v2/account/balance/ak$3N1WLMewMQPUyQBdEhXRSYee84RQNKJrECwbbseMkNsZhv1XLjpmiqjAkvSRpQ6kgWJMjq9dTmdQ3ekuhpscJk6LpjJYk4'
+curl -G 'http://127.0.0.1:3113/v2/account/balance/ak$3N1WLMewMQPUyQBdEhXRSYee84RQNKJrECwbbseMkNsZhv1XLjpmiqjAkvSRpQ6kgWJMjq9dTmdQ3ekuhpscJk6LpjJYk4'
 ```
 You shall read output like the following...
 ```


### PR DESCRIPTION
We have a new Client's `GET /account/balance/{account_pubkey}` API endpoint.
It replaces the old API for getting the balance which used to be part of the external gossip protocol.
[PR of the epoch change](https://github.com/aeternity/epoch/pull/679)