### PR TITLE
Remove mention of HTTPS for epoch API

### DIFF
--- a/epoch/api/README.md
+++ b/epoch/api/README.md
@@ -27,8 +27,6 @@ The epoch node exposes the following APIs:
     * It is **not** meant to be exposed on the Internet;
     * Its TCP port is configurable.
 
-The epoch node uses the plain HTTP protocol for its API endpoints during the testnet phase while it will use the HTTPS protocol in mainnet.
-
 ## WebSocket API definition
 
 ### Connection


### PR DESCRIPTION
Operator may implement HTTPS.

See also https://github.com/aeternity/protocol/pull/57#discussion_r177994828