### PR TITLE
[RFC] Gas fees for oracles in contracts

### DIFF
--- a/contracts/aevm.md
+++ b/contracts/aevm.md
@@ -29,16 +29,16 @@ Unused tokens stay on the contract account.
 The first argument in the call specifies which primop to call.
 The following arguments are encoded as Sophia data.
 
-| OpNo | Name                |          Value |             Arguments | Return value    |
-| ---- | ------------------- | -------------- | --------------------- | --------------- |
-|    1 | Spend               | `Amount : int` | `Recipient : address` | `Nil`           |
-|  100 | Oracle register     | (Unused.)      | `Acct : address, Sign : signature, QFee : int, TTL : int, QType : typerep, RType : typerep` | `Oracle : address` |
-|  101 | Oracle query        | `QFee : int`   | `Oracle : address, Query : ('a,'b), QTTL : int, RTTL : int` | `query : oracle_query('a, 'b)` |
-|  102 | Oracle respond      | (Unused.)      | `Oracle : address, Query : address, Sign : signature, R : 'a` | `()` |
-|  103 | Oracle extend       | (Unused.)      | `Oracle : address, Sign : signature, TTL : integer` | `()` |
-|  104 | Oracle get answer   | (Unused.)      | `Oracle : address, Query : address` | `option('b)` |
-|  105 | Oracle get question | (Unused.)      | `Oracle : address, Query : address` | `'a` |
-|  106 | Oracle query fee    | (Unused.)      | `Oracle : address`    | `int`           |
+| OpNo | Name                |          Value |             Arguments | Return value    | Gas cost |
+| ---- | ------------------- | -------------- | --------------------- | --------------- | -------- |
+|    1 | Spend               | `Amount : int` | `Recipient : address` | `Nil`           | TODO     |
+|  100 | Oracle register     | (Unused.)      | `Acct : address, Sign : signature, QFee : int, TTL : int, QType : typerep, RType : typerep` | `Oracle : address` | Static positive component + dynamic component proportional to oracle (relative) TTL argument `TTL` (TODO: Detail.) |
+|  101 | Oracle query        | `QFee : int`   | `Oracle : address, Query : ('a,'b), QTTL : int, RTTL : int` | `query : oracle_query('a, 'b)` | Static positive component + dynamic component proportional to query (relative) TTL argument `QTTL` (TODO: Detail.) |
+|  102 | Oracle respond      | (Unused.)      | `Oracle : address, Query : address, Sign : signature, R : 'a` | `()` | Static positive component + dynamic component proportional to response (relative) TTL in query (from `RTTL` argument of query primop) (TODO: Detail.) |
+|  103 | Oracle extend       | (Unused.)      | `Oracle : address, Sign : signature, TTL : integer` | `()` | Static positive component + dynamic component proportional to oracle (relative) TTL argument `TTL` (TODO: Detail.) |
+|  104 | Oracle get answer   | (Unused.)      | `Oracle : address, Query : address` | `option('b)` | Static positive component (TODO: Detail.) |
+|  105 | Oracle get question | (Unused.)      | `Oracle : address, Query : address` | `'a` | Static positive component (TODO: Detail.) |
+|  106 | Oracle query fee    | (Unused.)      | `Oracle : address`    | `int`           | Static positive component (TODO: Detail.) |
 
 ## New instructions
 


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/159686884

This RFC PR drafts doc update re gas fees of oracle primops, explicating that oracle primops pay the miner (both for minimum primop fee and for TTL of object on state trees) via gas (rather than tokens). Consequence of this is that, after changes [meant to go alongside this doc PR](https://www.pivotaltracker.com/story/show/159686884) are implemented, oracle transactions will pay TTL-related cost to miner as tokens while oracle primops will pay the same (TTL-related) cost to miner as gas (hence depending on gas price). Consideration of converting some token-based fees to gas-based fees is [tracked](https://www.pivotaltracker.com/story/show/159950510).

Recapping - from commit message of merged https://github.com/aeternity/epoch/pull/1439/commits/155e2b09505b95630892ecb8cd3576a733afead0 :

> * The *minimum tx fee* is meant to be expressed as static gas cost of primop.  Not implemented yet.

Meant to be implemented in scope of https://www.pivotaltracker.com/story/show/159686884

> * The *fee proportional to TTL* of object in state tree (oracle, oracle query, oracle response) is meant to be expressed as gas cost, computed by the primop.  Not implemented yet.

Meant to be implemented in scope of https://www.pivotaltracker.com/story/show/159686884

> * The *fee for oracle's service (query fee)* is debited as tokens from the account during oracle query primop execution, and credited (as tokens) during oracle response primop execution.  This fee is explicit among primop arguments.  (This is implemented.)

Implemented in https://www.pivotaltracker.com/n/projects/2159793/stories/158023291