### PR TITLE
Apply parameter changes in channel opening messages

### DIFF
--- a/epoch/api/channels_api_usage.md
+++ b/epoch/api/channels_api_usage.md
@@ -65,8 +65,8 @@ in the chain, and the others are metadata used for the connection itself.
 
   | Name | Type | Description | Required | Part of the `channel_create_tx` |
   | ---- | ---- | ----------- | -------- |------------------------------ |
-  | initiator | string | initiator's public key | Yes | Yes |
-  | responder | string | responder's public key | Yes | Yes |
+  | initiator_id | string | initiator's public key | Yes | Yes |
+  | responder_id | string | responder's public key | Yes | Yes |
   | lock_period | integer | amount of blocks for disputing a solo close | Yes | Yes |
   | push_amount | integer | initial deposit in favour of the responder by the initiator | Yes | No |
   | initiator_amount | integer | amount of tokens the initiator has committed to the channel | Yes | Yes |
@@ -82,8 +82,8 @@ in the chain, and the others are metadata used for the connection itself.
 
   | Name | Value |
   | ---- | ----- |
-  | initiator | ak$4Kr76woCtc3ehZ45K1sCrmgKX6gnh7qGhjSU1GZYqfLTTjtCgn |
-  | responder | ak$35Wxqf2cbzQF5hEV1j9AdXQFTMxqKCwM7iMKNGcqSv47MXAj68 |
+  | initiator_id | ak$4Kr76woCtc3ehZ45K1sCrmgKX6gnh7qGhjSU1GZYqfLTTjtCgn |
+  | responder_id | ak$35Wxqf2cbzQF5hEV1j9AdXQFTMxqKCwM7iMKNGcqSv47MXAj68 |
   | lock_period | 10 |
   | push_amount | 3 |
   | initiator_amount | 10 |
@@ -99,7 +99,7 @@ in the chain, and the others are metadata used for the connection itself.
 Using the set of prenegotiated parameters the initiator connects
 ```
 $ wscat --connect
-'localhost:3014/channel?initiator=ak$4Kr76woCtc3ehZ45K1sCrmgKX6gnh7qGhjSU1GZYqfLTTjtCgn&responder=ak$35Wxqf2cbzQF5hEV1j9AdXQFTMxqKCwM7iMKNGcqSv47MXAj68&lock_period=10&push_amount=3&initiator_amount=10&responder_amount=10&channel_reserve=2&ttl=1000&host=localhost&port=1234&role=initiator'
+'localhost:3014/channel?initiator_id=ak$4Kr76woCtc3ehZ45K1sCrmgKX6gnh7qGhjSU1GZYqfLTTjtCgn&responder_id=ak$35Wxqf2cbzQF5hEV1j9AdXQFTMxqKCwM7iMKNGcqSv47MXAj68&lock_period=10&push_amount=3&initiator_amount=10&responder_amount=10&channel_reserve=2&ttl=1000&host=localhost&port=1234&role=initiator'
 
 connected (press CTRL+C to quit)
 ```
@@ -110,7 +110,7 @@ Note the `role=initiator` as it is specific
 Using the set of prenegotiated parameters the responder connects
 ```
 $ wscat --connect
-'localhost:3014/channel?initiator=ak$4Kr76woCtc3ehZ45K1sCrmgKX6gnh7qGhjSU1GZYqfLTTjtCgn&responder=ak$35Wxqf2cbzQF5hEV1j9AdXQFTMxqKCwM7iMKNGcqSv47MXAj68&lock_period=10&push_amount=3&initiator_amount=10&responder_amount=10&channel_reserve=2&ttl=1000&port=1234&role=responder'
+'localhost:3014/channel?initiator_id=ak$4Kr76woCtc3ehZ45K1sCrmgKX6gnh7qGhjSU1GZYqfLTTjtCgn&responder_id=ak$35Wxqf2cbzQF5hEV1j9AdXQFTMxqKCwM7iMKNGcqSv47MXAj68&lock_period=10&push_amount=3&initiator_amount=10&responder_amount=10&channel_reserve=2&ttl=1000&port=1234&role=responder'
 
 connected (press CTRL+C to quit)
 ```


### PR DESCRIPTION
@ThomasArts had discovered an inconsistency in WebSocket API and protocol description.

The channel's WebSocket parameters are read [here](https://github.com/aeternity/epoch/blob/master/apps/aehttp/src/sc_ws_handler.erl#L599-L600)

This PR does not address the description of resuming the connection to an old preexisting channel (the reconnect to client). This is tracked as [Document in protocol opening a WebSocket for an existing channel](https://www.pivotaltracker.com/story/show/160339328)