### PR TITLE
Add parameter vm_version to Oracle register tx

### DIFF
--- a/serializations.md
+++ b/serializations.md
@@ -299,6 +299,7 @@ The recipient must be one of the following:
 , <ttl_value>     :: int()
 , <fee>           :: int()
 , <ttl>           :: int()
+, <vm_version>    :: int()
 ]
 ```
 


### PR DESCRIPTION
Add missing parameter vm_version to the Oracle register transaction serialization format