### PR TITLE
fix mistake in example

### DIFF
--- a/contracts/sophia.md
+++ b/contracts/sophia.md
@@ -443,7 +443,7 @@ contain a map or a function type.
 A value of record type is constructed by giving a value for each of the fields.
 For the example above,
 ```
-  function new_account(name) =
+  function new_account(name: string) : account =
     {name = name, balance = 0, history = []}
 ```
 Maps are constructed similarly, with keys enclosed in square brackets


### PR DESCRIPTION
- Fixing a mistake in constructing record via function example

The passed parameter was not given a type and the function was not returning any value which it should as this was the example aiming to do.