### PR TITLE
Initial doc update for client reconnect

### DIFF
--- a/node/api/channels_api_usage.md
+++ b/node/api/channels_api_usage.md
@@ -29,6 +29,7 @@ These are used for the scenario when all parties behave correctly and as
 expected. The flow is the following:
 
 1. [Channel open](#channel-open)
+  * [Client reconnect](#client-reconnect)
 2. [Channel off-chain update](#channel-off-chain-update)
   * [Transfer](#transfer)
   * [Create a contract](#create-a-contract)
@@ -464,6 +465,34 @@ present the initial off-chain state:
   "version": 1
 }
 ```
+
+### Client reconnect
+Once the `channel_create_tx` has been signed, the client Websocket connection may close
+without causing the FSM to terminate. The client may reconnect by signing a special
+`channel_client_reconnect_tx` transaction, partly to identify the right FSM instance
+to connect to, and partly to prove identity. The transaction has the following structure:
+
+ | Name | Type | Description |
+ | ---- | ---- | ----------- |
+ | channel id | string | ID of the channel |
+ | role | string | Role of the instance (initiator or responder) |
+ | pub key | string | Public key of the client |
+
+Information about serialization can be found [here](../../serializations.md#channel-client-reconnect-transaction).
+
+After signing the reconnect transaction, the client connects using the parameters `protocol`
+and `reconnect_tx` as illustrated below. Note that the `reconnect_tx` parameter uses a
+serialized transaction.
+
+```
+$ wscat --connect 'localhost:3014/channel?protocol=json-rpc&reconnect_tx=tx_%2BJwLAfhCuEBcOkx9CFjb8i7AsTT5%2BIkuSxG5SKKrSLweRz%2BeIThEXNIq42AQjKyBQGDkT6QEyxbQH5XSSaaojvt%2B2BYJu2wNuFT4UoICPwGhBrBnp1GFwypFOxF3uxx9KK6ZNyKMgeZJFKRgUhZ4U1WfiWluaXRpYXRvcqEBQrhkAQ8qujZTeNSsuZiVkaLuejuljb%2BPfdvSsAm2SNIJAuU9'
+
+connected (press CTRL+C to quit)
+```
+
+While the client is disconnected, the corresponding FSM will reject any protocol request that
+requires signing. An attempt to reconnect to an FSM that already has a client connected will
+be rejected.
 
 ## Channel off-chain update
 After the channel has been opened and before it has been closed there is a

--- a/serializations.md
+++ b/serializations.md
@@ -778,7 +778,7 @@ wants to reconnect to an already running FSM. It cannot be introduced into the
 mempool. The elements of the transaction are:
 * The channel id of the channel that the client wants to connect to
 * The role (`initiator` or `responder`) of the FSM instance in question
-* The public key of the client; must correspond to the private key used for
+* The public key of the client; must correspond to the authentication used for
   signing the transaction.
 
 ```

--- a/serializations.md
+++ b/serializations.md
@@ -235,6 +235,7 @@ subsequent sections divided by object.
 | Channel off-chain update withdrawal | 572 |
 | Channel off-chain update create contract | 573 |
 | Channel off-chain update call contract | 574 |
+| Channel client reconnect transaction | 575 |
 | Channel | 58 |
 | Channel snapshot transaction | 59 |
 | POI | 60 |
@@ -767,6 +768,23 @@ version 2, from Fortuna release
 [ <channel_id>       :: id()
 , <round>            :: int()
 , <state_hash>       :: binary()
+]
+```
+
+#### Channel client reconnect transaction
+
+The channel client reconnect transaction is used only when a Websocket client
+wants to reconnect to an already running FSM. It cannot be introduced into the
+mempool. The elements of the transaction are:
+* The channel id of the channel that the client wants to connect to
+* The role (`initiator` or `responder`) of the FSM instance in question
+* The public key of the client; must correspond to the private key used for
+  signing the transaction.
+
+```
+[ <channel_id>    :: id()
+, <role>          :: binary()
+, <pub_key>       :: id()
 ]
 ```
 


### PR DESCRIPTION
See [PT #167617278](https://www.pivotaltracker.com/story/show/167617278)

Documentation for https://github.com/aeternity/aeternity/pull/2602

> * State Channels Websocket clients can now reconnect and re-attach to the FSM, using a special signed offchain transaction. While the client is disconnected, the corresponding FSM will reject requests that require signatures.
