### PR TITLE
Pt 167617278 allow sc ws to disconnect 2

### DIFF
--- a/node/api/channels_api_usage.md
+++ b/node/api/channels_api_usage.md
@@ -29,6 +29,7 @@ These are used for the scenario when all parties behave correctly and as
 expected. The flow is the following:
 
 1. [Channel open](#channel-open)
+  * [Client reconnect](#client-reconnect)
 2. [Channel off-chain update](#channel-off-chain-update)
   * [Transfer](#transfer)
   * [Create a contract](#create-a-contract)
@@ -464,6 +465,34 @@ present the initial off-chain state:
   "version": 1
 }
 ```
+
+### Client reconnect
+Once the `channel_create_tx` has been signed, the client Websocket connection may close
+without causing the FSM to terminate. The client may reconnect by signing a special
+`channel_client_reconnect_tx` transaction, partly to identify the right FSM instance
+to connect to, and partly to prove identity. The transaction has the following structure:
+
+ | Name | Type | Description |
+ | ---- | ---- | ----------- |
+ | channel id | string | ID of the channel |
+ | role | string | Role of the instance (initiator or responder) |
+ | pub key | string | Public key of the client |
+
+Information about serialization can be found [here](../../serializations.md#channel-client-reconnect-transaction).
+
+After signing the reconnect transaction, the client connects using the parameters `protocol`
+and `reconnect_tx` as illustrated below. Note that the `reconnect_tx` parameter uses a
+serialized transaction.
+
+```
+$ wscat --connect 'localhost:3014/channel?protocol=json-rpc&reconnect_tx=tx_%2BJwLAfhCuEBcOkx9CFjb8i7AsTT5%2BIkuSxG5SKKrSLweRz%2BeIThEXNIq42AQjKyBQGDkT6QEyxbQH5XSSaaojvt%2B2BYJu2wNuFT4UoICPwGhBrBnp1GFwypFOxF3uxx9KK6ZNyKMgeZJFKRgUhZ4U1WfiWluaXRpYXRvcqEBQrhkAQ8qujZTeNSsuZiVkaLuejuljb%2BPfdvSsAm2SNIJAuU9'
+
+connected (press CTRL+C to quit)
+```
+
+While the client is disconnected, the corresponding FSM will reject any protocol request that
+requires signing. An attempt to reconnect to an FSM that already has a client connected will
+be rejected.
 
 ## Channel off-chain update
 After the channel has been opened and before it has been closed there is a

--- a/node/api/channels_api_usage.md
+++ b/node/api/channels_api_usage.md
@@ -475,6 +475,7 @@ to connect to, and partly to prove identity. The transaction has the following s
  | Name | Type | Description |
  | ---- | ---- | ----------- |
  | channel id | string | ID of the channel |
+ | round | integer | Must be higher than at the last reconnect |
  | role | string | Role of the instance (initiator or responder) |
  | pub key | string | Public key of the client |
 
@@ -485,7 +486,7 @@ and `reconnect_tx` as illustrated below. Note that the `reconnect_tx` parameter 
 serialized transaction.
 
 ```
-$ wscat --connect 'localhost:3014/channel?protocol=json-rpc&reconnect_tx=tx_%2BJwLAfhCuEBcOkx9CFjb8i7AsTT5%2BIkuSxG5SKKrSLweRz%2BeIThEXNIq42AQjKyBQGDkT6QEyxbQH5XSSaaojvt%2B2BYJu2wNuFT4UoICPwGhBrBnp1GFwypFOxF3uxx9KK6ZNyKMgeZJFKRgUhZ4U1WfiWluaXRpYXRvcqEBQrhkAQ8qujZTeNSsuZiVkaLuejuljb%2BPfdvSsAm2SNIJAuU9'
+$ wscat --connect 'localhost:3014/channel?protocol=json-rpc&reconnect_tx=tx_%2BJ0LAfhCuECD0kyElzq1A4bRqUUlIvwqo3UpNLZr07K6f6ZzCMjOY6nVLowEyewiEfDOGu0yy%2BrS2pSOWZzumSKLpNAOwQsBuFX4U4ICPwGhBiPYP7m2R8Z36J9C1yWyKO6C0GoclMWjkh8mGyYcwiNkAYlpbml0aWF0b3KhARZ7k%2B1MUXursizzqkphuO8bCDRo8DrnsRvekHG5Ry3bV0P6XA%3D%3D'
 
 connected (press CTRL+C to quit)
 ```

--- a/serializations.md
+++ b/serializations.md
@@ -777,12 +777,14 @@ The channel client reconnect transaction is used only when a Websocket client
 wants to reconnect to an already running FSM. It cannot be introduced into the
 mempool. The elements of the transaction are:
 * The channel id of the channel that the client wants to connect to
+* A round (integer), which must be higher than at the last attempt
 * The role (`initiator` or `responder`) of the FSM instance in question
 * The public key of the client; must correspond to the private key used for
   signing the transaction.
 
 ```
 [ <channel_id>    :: id()
+, <round>         :: int()
 , <role>          :: binary()
 , <pub_key>       :: id()
 ]

--- a/serializations.md
+++ b/serializations.md
@@ -235,6 +235,7 @@ subsequent sections divided by object.
 | Channel off-chain update withdrawal | 572 |
 | Channel off-chain update create contract | 573 |
 | Channel off-chain update call contract | 574 |
+| Channel client reconnect transaction | 575 |
 | Channel | 58 |
 | Channel snapshot transaction | 59 |
 | POI | 60 |
@@ -767,6 +768,23 @@ version 2, from Fortuna release
 [ <channel_id>       :: id()
 , <round>            :: int()
 , <state_hash>       :: binary()
+]
+```
+
+#### Channel client reconnect transaction
+
+The channel client reconnect transaction is used only when a Websocket client
+wants to reconnect to an already running FSM. It cannot be introduced into the
+mempool. The elements of the transaction are:
+* The channel id of the channel that the client wants to connect to
+* The role (`initiator` or `responder`) of the FSM instance in question
+* The public key of the client; must correspond to the private key used for
+  signing the transaction.
+
+```
+[ <channel_id>    :: id()
+, <role>          :: binary()
+, <pub_key>       :: id()
 ]
 ```
 


### PR DESCRIPTION
Alternative to #387 - documenting the use of `round` in the reconnect_tx in order to guard against replay attacks. See https://github.com/aeternity/aeternity/pull/2603